### PR TITLE
Made MediaQuerySelector and Device exportable and accessible

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,14 @@ import ResponsiveComponent from "./ResponsiveComponent";
 import responsive from "./Responsive";
 import {MediaQuery} from "./MediaQuery";
 import ResponsiveStyleSheet from "./ResponsiveStyleSheet";
+import MediaQuerySelector from "./MediaQuerySelector";
+import Device from "./Device";
 
 export {
     MediaQuery,
     ResponsiveComponent,
     ResponsiveStyleSheet,
+    MediaQuerySelector,
+    Device,
     responsive
 }


### PR DESCRIPTION
By some reason I was not able to evaluate an example code listed in the doc

```jsx
MediaQuerySelector.query(...)
```

this PR makes missing modules to be available for import