### PR TITLE
Added a better HOC API

### DIFF
--- a/lib/Responsive.js
+++ b/lib/Responsive.js
@@ -18,32 +18,30 @@ function calcStyles(width: number, height: number, styles: MediaQueryStyle[]): S
     return merge.apply(null, selectedStyles);
 }
 
-export default function Responsive(styles: MediaQueryStyle[] = []): ReactClass<*> {
+export default function Responsive(WrapperComponent: ReactClass<*>, styles: MediaQueryStyle[] = []): ReactClass<*> {
     const dims = Device.dimensions;
     const initialStyles = calcStyles(dims.window.width, dims.window.height, styles);
-    return (WrapperComponent: ReactClass<*>) => {
-        return class ResponsiveWrapper extends Component {
-            state: State = {
-                dims: dims,
-                styles: initialStyles
-            };
-            subscription: DimensionChangeSubscription;
+    return class ResponsiveWrapper extends Component {
+        state: State = {
+            dims: dims,
+            styles: initialStyles
+        };
+        subscription: DimensionChangeSubscription;
 
-            componentWillMount() {
-                this.subscription = Device.subscribeToDimensionChanges(dims => {
-                    const {width, height} = dims.window;
-                    const compStyles: StyleSheet.Styles[] = calcStyles(width, height, styles)
-                    this.setState({dims, styles: compStyles})
-                });
-            }
-
-            componentWillUnmount() {
-                this.subscription.unsubscribe();
-            }
-
-            render = () => (
-                <WrapperComponent window={this.state.dims.window}  responsiveStyles={this.state.styles} {...this.props} />
-            )
+        componentWillMount() {
+            this.subscription = Device.subscribeToDimensionChanges(dims => {
+                const {width, height} = dims.window;
+                const compStyles: StyleSheet.Styles[] = calcStyles(width, height, styles)
+                this.setState({dims, styles: compStyles})
+            });
         }
+
+        componentWillUnmount() {
+            this.subscription.unsubscribe();
+        }
+
+        render = () => (
+            <WrapperComponent window={this.state.dims.window}  responsiveStyles={this.state.styles} {...this.props} />
+        )
     }
 }

--- a/lib/Responsive.js
+++ b/lib/Responsive.js
@@ -1,11 +1,49 @@
 // @flow
-import React from "react";
-import ResponsiveComponent from "./ResponsiveComponent";
+import React, {Component} from "react";
+import {StyleSheet} from "react-native";
+import { merge } from "lodash";
+import Device, {AllDimensions, DimensionChangeSubscription} from "./Device";
+import MediaQuerySelector from "./MediaQuerySelector";
+import type { MediaQueryStyle } from "./ResponsiveStyleSheet";
 
-export default function Responsive(WrapperComponent: ReactClass<*>): ReactClass<*> {
-    return class ResponsiveComponentWrapper extends ResponsiveComponent {
-        render(): React$Element<*> {
-            return <WrapperComponent window={this.state.window} {...this.props} />;
+type State = {
+    dims: AllDimensions,
+    styles: StyleSheet.Styles
+};
+
+function calcStyles(width: number, height: number, styles: MediaQueryStyle[]): StyleSheet.Styles {
+    const selectedStyles: StyleSheet.Styles[] = styles.reduce((styles, style) => {
+            return MediaQuerySelector.query(style.query, width, height) ? styles.concat(style.style) : styles
+    }, []);
+    return merge.apply(null, selectedStyles);
+}
+
+export default function Responsive(styles: MediaQueryStyle[] = []): ReactClass<*> {
+    const dims = Device.dimensions;
+    const initialStyles = calcStyles(dims.window.width, dims.window.height, styles);
+    return (WrapperComponent: ReactClass<*>) => {
+        return class ResponsiveWrapper extends Component {
+            state: State = {
+                dims: dims,
+                styles: initialStyles
+            };
+            subscription: DimensionChangeSubscription;
+
+            componentWillMount() {
+                this.subscription = Device.subscribeToDimensionChanges(dims => {
+                    const {width, height} = dims.window;
+                    const compStyles: StyleSheet.Styles[] = calcStyles(width, height, styles)
+                    this.setState({dims, styles: compStyles})
+                });
+            }
+
+            componentWillUnmount() {
+                this.subscription.unsubscribe();
+            }
+
+            render = () => (
+                <WrapperComponent window={this.state.dims.window}  responsiveStyles={this.state.styles} {...this.props} />
+            )
         }
     }
 }

--- a/lib/ResponsiveStyleSheet.js
+++ b/lib/ResponsiveStyleSheet.js
@@ -4,7 +4,7 @@ import {StyleSheet} from "react-native";
 import Device from "./Device";
 import MediaQuerySelector, {MediaQuery} from "./MediaQuerySelector";
 
-type MediaQueryStyle = {
+export type MediaQueryStyle = {
     query: MediaQuery,
     style: StyleSheet.Styles
 };


### PR DESCRIPTION
This adds the ability to pass responsive styles in as an argument to the responsive higher order component, and then inject the correct styles as a `responsiveStyles` prop.  An example usage would be: 
```javascript
export default class Buttons extends React.Component {
    render() {
        const {responsiveStyle} = this.props;
        return <View style={responsiveStyle.btns}>
            <Button label="Login" primary style={responsiveStyle.btn} />
            <Button label="Sign Up" style={responsiveStyle.btn} />
        </View>;
    }
}
const responsiveStyles = [{
            query: { orientation: "landscape" },
            style: {
                btns: {
                    flexDirection: "row"
                },
                btn: {
                    flex: 1
                }
            }
        },
        {
            query: { orientation: "portrait" },
            style: {
                btns: {
                    alignSelf: "stretch"
                },
                btn: {
                    flex: 0
                }
            }
        }];

export default responsive(responsiveStyles)(Buttons);
```