### PR TITLE
fix typescript error

### DIFF
--- a/__tests__/__snapshots__/index.tsx.snap
+++ b/__tests__/__snapshots__/index.tsx.snap
@@ -3,5 +3,9 @@
 exports[`renders MediaQuery 1`] = `
 <View>
   test
+  <Text>
+    test
+  </Text>
+  8
 </View>
 `;

--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -1,4 +1,4 @@
-import { View } from "react-native";
+import { View, Text } from "react-native";
 import React from "react";
 import renderer from "react-test-renderer";
 import { MediaQuery, mediaQuery, getStylesheet } from "../src";
@@ -9,6 +9,12 @@ it("renders MediaQuery", () => {
       <View>
         <MediaQuery minHeight={450} orientation="portrait">
           test
+        </MediaQuery>
+        <MediaQuery minHeight={450} orientation="portrait">
+          <Text>test</Text>
+        </MediaQuery>
+        <MediaQuery minHeight={450} orientation="portrait">
+          {3 + 5}
         </MediaQuery>
       </View>
     )

--- a/src/MediaQuery.tsx
+++ b/src/MediaQuery.tsx
@@ -56,10 +56,10 @@ export const mediaQuery = (
 };
 
 interface MediaQueryProps extends MediaQuery {
-  children?: React.ReactNode;
+  children: React.ReactNode;
 }
 
-export default ({ children, ...props }: MediaQueryProps): any => {
+export default ({ children, ...props }: MediaQueryProps): React.ReactNode => {
   const { width, height } = useDimensions();
   const val = mediaQuery(props, width, height);
   if (val) {

--- a/src/MediaQuery.tsx
+++ b/src/MediaQuery.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode } from "react";
 import { PixelRatio, Platform } from "react-native";
 import useDimensions from "./useDimensions";
 

--- a/src/MediaQuery.tsx
+++ b/src/MediaQuery.tsx
@@ -56,10 +56,10 @@ export const mediaQuery = (
 };
 
 interface MediaQueryProps extends IMediaQuery {
-  children?: React.ReactNode;
+  children?: any;
 }
 
-export default ({ children, ...props }: MediaQueryProps): any => {
+export default ({ children, ...props }: MediaQueryProps) => {
   const { width, height } = useDimensions();
   const val = mediaQuery(props, width, height);
   if (val) {

--- a/src/MediaQuery.tsx
+++ b/src/MediaQuery.tsx
@@ -59,7 +59,7 @@ interface MediaQueryProps extends IMediaQuery {
   children?: React.ReactNode;
 }
 
-export default ({ children, ...props }: MediaQueryProps) => {
+export default ({ children, ...props }: MediaQueryProps): any => {
   const { width, height } = useDimensions();
   const val = mediaQuery(props, width, height);
   if (val) {

--- a/src/MediaQuery.tsx
+++ b/src/MediaQuery.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { PixelRatio, Platform } from "react-native";
 import useDimensions from "./useDimensions";
 
@@ -55,10 +56,10 @@ export const mediaQuery = (
 };
 
 interface MediaQueryProps extends MediaQuery {
-  children?: any;
+  children?: ReactNode;
 }
 
-export default ({ children, ...props }: MediaQueryProps) => {
+export default ({ children, ...props }: MediaQueryProps): any => {
   const { width, height } = useDimensions();
   const val = mediaQuery(props, width, height);
   if (val) {

--- a/src/MediaQuery.tsx
+++ b/src/MediaQuery.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { PixelRatio, Platform } from "react-native";
 import useDimensions from "./useDimensions";
 

--- a/src/MediaQuery.tsx
+++ b/src/MediaQuery.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import React from "react";
 import { PixelRatio, Platform } from "react-native";
 import useDimensions from "./useDimensions";
 
@@ -56,7 +56,7 @@ export const mediaQuery = (
 };
 
 interface MediaQueryProps extends MediaQuery {
-  children?: ReactNode;
+  children?: React.ReactNode;
 }
 
 export default ({ children, ...props }: MediaQueryProps): any => {


### PR DESCRIPTION
Hi @wcandillon, I keep noticing this error whenever I was using MediaQuery

![react-native-responsive-ui](https://user-images.githubusercontent.com/5825929/60389949-9e6b0b80-9a99-11e9-9a18-ee0372b2ae1f.PNG)

It gave this warning `JSX element type '{}' is not a constructor function for JSX elements.
  Type '{}' is missing the following properties from type 'Element': type, props, keyts(2605)`

I figured out that this is due to typescript assuming that a functional component will return a react constructor, but that is not the case with MediaQuery because it can sometimes return null or sometimes return string or sometimes returns a number depending on what is passed as a children prop to the MediaQuery. So I set children equal to any because children doesn't always have to be a ReactNode, but can also be a string that you conditionally show if you choose to pass a string in as children. My test for MediaQuery shows an example where it is a string being passed a children versus a ReactNode