### PR TITLE
Fix typing detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "react-native": "src/index.ts",
-  "types": "dist/typescript/src/index.d.ts",
+  "types": "dist/typescript/index.d.ts",
   "scripts": {
     "prepare": "bob build",
     "lint": "eslint src/**/* __tests__/**/*.tsx",


### PR DESCRIPTION
Currently, when using the project with TypeScript, there are errors that the type definitions are not defined. This is because the `package.json` "types" property is misaligned with the build location of the `index.d.ts` file that contains the definitions.

This PR fixes #62