### PR TITLE
perf: reduce bundle size by migrating to lodash-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@release-it/conventional-changelog": "^2.0.0",
     "@testing-library/react-native": "^8.0.0-rc.1",
     "@types/jest": "^26.0.0",
-    "@types/lodash": "^4.14.168",
+    "@types/lodash-es": "^4.17.4",
     "@types/react": "^16.9.19",
     "@types/react-native": "0.62.13",
     "commitlint": "^11.0.0",
@@ -62,9 +62,9 @@
     "pod-install": "^0.1.0",
     "prettier": "^2.0.5",
     "react": "16.13.1",
-    "react-test-renderer": "16.13.1",
     "react-native": "0.63.4",
     "react-native-builder-bob": "^0.18.0",
+    "react-test-renderer": "16.13.1",
     "release-it": "^14.2.2",
     "typescript": "^4.1.3"
   },
@@ -73,11 +73,13 @@
     "react-native": "*"
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash-es": "^4.17.21"
   },
   "jest": {
     "preset": "react-native",
-    "setupFilesAfterEnv": ["./src/__tests__/setup.ts"],
+    "setupFilesAfterEnv": [
+      "./src/__tests__/setup.ts"
+    ],
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/",

--- a/src/useStylesheet.ts
+++ b/src/useStylesheet.ts
@@ -1,4 +1,4 @@
-import * as _ from "lodash";
+import {merge as _merge, cloneDeep as _cloneDeep} from "lodash";
 import type { ViewStyle, TextStyle, ImageStyle } from "react-native";
 
 import { mediaQuery, MediaQuery } from "./MediaQuery";
@@ -17,10 +17,10 @@ export const getStylesheet = <T extends Record<string, unknown>>(
   const selectedStyles: NamedStyles<T>[] = [];
   styles.forEach((style) =>
     mediaQuery(style.query, width, height)
-      ? selectedStyles.push(_.cloneDeep(style.style))
+      ? selectedStyles.push(_cloneDeep(style.style))
       : undefined
   );
-  return _.merge.apply<null, NamedStyles<T>[], NamedStyles<T>>(
+  return _merge.apply<null, NamedStyles<T>[], NamedStyles<T>>(
     null,
     selectedStyles
   );

--- a/src/useStylesheet.ts
+++ b/src/useStylesheet.ts
@@ -1,4 +1,4 @@
-import {merge as _merge, cloneDeep as _cloneDeep} from "lodash";
+import { merge as _merge, cloneDeep as _cloneDeep } from "lodash-es";
 import type { ViewStyle, TextStyle, ImageStyle } from "react-native";
 
 import { mediaQuery, MediaQuery } from "./MediaQuery";
@@ -20,6 +20,7 @@ export const getStylesheet = <T extends Record<string, unknown>>(
       ? selectedStyles.push(_cloneDeep(style.style))
       : undefined
   );
+  // eslint-disable-next-line prefer-spread
   return _merge.apply<null, NamedStyles<T>[], NamedStyles<T>>(
     null,
     selectedStyles

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,7 +1931,14 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.168":
+"@types/lodash-es@^4.17.4":
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.4.tgz#b2e440d2bf8a93584a9fd798452ec497986c9b97"
+  integrity sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
@@ -6454,6 +6461,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
This PR migrates us from using `lodash` to `lodash-es` in order for better tree-shaking.