### PR TITLE
[FIX] useDimensions initial value

### DIFF
--- a/src/useDimensions.ts
+++ b/src/useDimensions.ts
@@ -1,10 +1,8 @@
 import { useEffect, useState } from "react";
 import { Dimensions, ScaledSize } from "react-native";
 
-const dims = Dimensions.get("window");
-
 const useDimensions = () => {
-  const [dimensions, setDimensions] = useState(dims);
+  const [dimensions, setDimensions] = useState(Dimensions.get("window"));
 
   const onChange = ({
     window: { width, height, scale, fontScale },


### PR DESCRIPTION
If we just use useDimensions at a component that is not rendered as a first component, like a modal, that can be instantiated after some orientation change, so the dims (initialValue) will be wrong.
Correct me if I wrong.
Feel free to close this if doesn't make any sense to v3.
Thanks in advance @wcandillon.

cc @crutchcorn.